### PR TITLE
fix(rendering): std140 padding for FreGSPass::PushConstants

### DIFF
--- a/include/SpectraForge/rendering/FreGSPass.h
+++ b/include/SpectraForge/rendering/FreGSPass.h
@@ -20,6 +20,7 @@
 #include <vulkan/vulkan.hpp>
 #include <glm/glm.hpp>
 #include <vector>
+#include <cstddef> // for offsetof in static_asserts
 
 namespace spectraforge {
 namespace rendering {
@@ -131,11 +132,17 @@ private:
         float freqScale;
         uint32_t subbandLevel;
         float foveaRadius;
+        uint32_t padding0; // std140 padding to align subsequent vec2 to 8 bytes
         glm::vec2 foveaCenter;
         uint32_t maxGaussians;
     } pushConstants_;
+
+    // Compile-time layout validation for std140 expectations
+    static_assert(offsetof(PushConstants, foveaCenter) == 24,
+                  "PushConstants::foveaCenter must be 8-byte aligned (offset 24) for std140");
+    static_assert(offsetof(PushConstants, maxGaussians) == 32,
+                  "PushConstants::maxGaussians must follow foveaCenter at offset 32");
 };
 
 } // namespace rendering
 } // namespace spectraforge
-


### PR DESCRIPTION
Fix std140 alignment for `glm::vec2 foveaCenter` in `FreGSPass::PushConstants` by adding explicit 4-byte padding after `foveaRadius` and compile-time offset checks.

- Add `padding0` to satisfy std140 vec2 alignment
- Add `static_assert` offset checks for `foveaCenter` and `maxGaussians`
- No API changes; shader push constants now correctly mapped

Closes #22

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add padding and compile-time `offsetof` checks to std140-align `FreGSPass::PushConstants`.
> 
> - **Rendering**:
>   - **`include/SpectraForge/rendering/FreGSPass.h`** — `PushConstants` layout fixes:
>     - Add `padding0` after `foveaRadius` to align `glm::vec2 foveaCenter` per std140.
>     - Add `static_assert` `offsetof` checks for `foveaCenter` (offset 24) and `maxGaussians` (offset 32).
>     - Include `<cstddef>` to enable `offsetof`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37a0bec0c119810d3c2046416cd8c9d40dc1f2ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->